### PR TITLE
Update ical-filter-proxy chart to helm-chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 # helm-charts
 
+Public Helm chart repository for charts maintained by [yungwood](https://github.com/yungwood).
+
 ## Usage
 
 [Helm](https://helm.sh) must be installed to use the charts.
 Please refer to Helm's [documentation](https://helm.sh/docs/) to get started.
 
-Once Helm is set up properly, add the repo as follows:
+Once Helm is set up, add the repo:
 
 ```console
 helm repo add yungwood https://yungwood.github.io/helm-charts/
@@ -16,9 +18,30 @@ You can then run `helm search repo yungwood` to see the charts.
 ## Charts
 
 - [ical-filter-proxy](https://github.com/yungwood/helm-charts/tree/master/charts/ical-filter-proxy)
+  - Application: [yungwood/ical-filter-proxy](https://github.com/yungwood/ical-filter-proxy)
+  - Source of truth: synced from the application repository
 
 ```bash
-helm install --name your-release yungwood/ical-filter-proxy
+helm install your-release yungwood/ical-filter-proxy
 ```
 
 Also see [artifact hub](https://artifacthub.io/packages/search?repo=yungwood) for a complete list.
+
+## Publishing
+
+Chart releases are published from this repository to GitHub Pages at:
+
+```text
+https://yungwood.github.io/helm-charts/
+```
+
+Changes under `charts/` are linted and install-tested on pull requests. Merged
+chart changes on the default branch are packaged and released by GitHub Actions.
+
+For application charts, the preferred workflow is for the application repository
+to own the chart source alongside the application code, then sync the rendered
+chart directory into this repository under `charts/<chart-name>`. This keeps the
+chart close to the app it deploys while preserving a single public Helm
+repository URL.
+
+For standalone charts, the chart source may live directly in this repository.

--- a/charts/ical-filter-proxy/Chart.yaml
+++ b/charts/ical-filter-proxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ical-filter-proxy
 description: iCal proxy with support for user-defined filtering rules
 type: application
-version: 0.0.5
-appVersion: "0.2.1"
+version: 0.0.0
+appVersion: "unreleased"
 maintainers:
   - name: yungwood

--- a/charts/ical-filter-proxy/Chart.yaml
+++ b/charts/ical-filter-proxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ical-filter-proxy
 description: iCal proxy with support for user-defined filtering rules
 type: application
-version: 0.0.0
-appVersion: "unreleased"
+version: 0.3.0
+appVersion: "0.3.0"
 maintainers:
   - name: yungwood

--- a/charts/ical-filter-proxy/templates/deployment.yaml
+++ b/charts/ical-filter-proxy/templates/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "ical-filter-proxy.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
-  revisionHistoryLimit: {{ .Values.revisionHistoryLimit | default "3" }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels:
       {{- include "ical-filter-proxy.selectorLabels" . | nindent 6 }}
@@ -36,8 +36,10 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- with .Values.args }}
           args:
+            - -port
+            - {{ .Values.app.port | quote }}
+          {{- with .Values.args }}
             {{- toYaml . | nindent 12  }}
           {{- end }}
           {{- with .Values.command }}
@@ -46,7 +48,7 @@ spec:
           {{- end }}
           ports:
             - name: http
-              containerPort: {{ .Values.service.port }}
+              containerPort: {{ .Values.app.port }}
               protocol: TCP
           livenessProbe:
             {{- toYaml .Values.livenessProbe | nindent 12 }}

--- a/charts/ical-filter-proxy/values.schema.json
+++ b/charts/ical-filter-proxy/values.schema.json
@@ -6,11 +6,34 @@
       "type": "object"
     },
     "args": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "app": {
+      "additionalProperties": false,
+      "properties": {
+        "port": {
+          "maximum": 65535,
+          "minimum": 1,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "port"
+      ],
+      "type": "object"
+    },
+    "command": {
+      "items": {
+        "type": "string"
+      },
       "type": "array"
     },
     "config": {
+      "additionalProperties": false,
       "properties": {
-        "additionalProperties": false,
         "calendars": {
           "items": {
             "additionalProperties": false,
@@ -35,6 +58,9 @@
                         "summary": {
                           "additionalProperties": false,
                           "properties": {
+                            "empty": {
+                              "type": "boolean"
+                            },
                             "prefix": {
                               "type": "string"
                             },
@@ -53,6 +79,9 @@
                         "description": {
                           "additionalProperties": false,
                           "properties": {
+                            "empty": {
+                              "type": "boolean"
+                            },
                             "prefix": {
                               "type": "string"
                             },
@@ -71,6 +100,30 @@
                         "location": {
                           "additionalProperties": false,
                           "properties": {
+                            "empty": {
+                              "type": "boolean"
+                            },
+                            "prefix": {
+                              "type": "string"
+                            },
+                            "suffix": {
+                              "type": "string"
+                            },
+                            "contains": {
+                              "type": "string"
+                            },
+                            "regex": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "url": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "empty": {
+                              "type": "boolean"
+                            },
                             "prefix": {
                               "type": "string"
                             },
@@ -145,6 +198,18 @@
                             }
                           },
                           "type": "object"
+                        },
+                        "url": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "replace": {
+                              "type": "string"
+                            },
+                            "remove": {
+                              "type": "boolean"
+                            }
+                          },
+                          "type": "object"
                         }
                       },
                       "type": "object"
@@ -174,6 +239,34 @@
               "name"
             ],
             "allOf": [
+              {
+                "not": {
+                  "anyOf": [
+                    {
+                      "required": [
+                        "public",
+                        "token"
+                      ],
+                      "properties": {
+                        "public": {
+                          "const": true
+                        }
+                      }
+                    },
+                    {
+                      "required": [
+                        "public",
+                        "token_file"
+                      ],
+                      "properties": {
+                        "public": {
+                          "const": true
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
               {
                 "anyOf": [
                   {
@@ -282,9 +375,6 @@
     "ingress": {
       "properties": {
         "annotations": {
-          "additionalProperties": {
-            "type": "string"
-          },
           "properties": {},
           "type": "object"
         },
@@ -367,19 +457,14 @@
       "type": "object"
     },
     "replicaCount": {
+      "minimum": 0,
+      "type": "integer"
+    },
+    "revisionHistoryLimit": {
+      "minimum": 0,
       "type": "integer"
     },
     "resources": {
-      "properties": {
-        "limits": {
-          "properties": {},
-          "type": "object"
-        },
-        "requests": {
-          "properties": {},
-          "type": "object"
-        }
-      },
       "type": "object"
     },
     "securityContext": {
@@ -389,6 +474,8 @@
     "service": {
       "properties": {
         "port": {
+          "maximum": 65535,
+          "minimum": 1,
           "type": "integer"
         },
         "type": {
@@ -400,9 +487,6 @@
     "serviceAccount": {
       "properties": {
         "annotations": {
-          "additionalProperties": {
-            "type": "string"
-          },
           "properties": {},
           "type": "object"
         },
@@ -423,51 +507,27 @@
     },
     "volumeMounts": {
       "items": {
-        "properties": {
-          "mountPath": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "readOnly": {
-            "type": "boolean"
-          }
-        },
         "type": "object"
       },
       "type": "array"
     },
     "volumes": {
       "items": {
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "secret": {
-            "properties": {
-              "optional": {
-                "type": "boolean"
-              },
-              "secretName": {
-                "type": "string"
-              }
-            },
-            "type": "object"
-          }
-        },
         "type": "object"
       },
       "type": "array"
     }
   },
   "required": [
+    "app",
+    "command",
     "image",
     "config",
     "extraResources",
     "livenessProbe",
     "readinessProbe",
-    "replicaCount"
+    "replicaCount",
+    "revisionHistoryLimit"
   ],
   "type": "object"
 }

--- a/charts/ical-filter-proxy/values.yaml
+++ b/charts/ical-filter-proxy/values.yaml
@@ -8,7 +8,12 @@ nameOverride: ""
 fullnameOverride: ""
 
 replicaCount: 1
+revisionHistoryLimit: 3
 
+app:
+  port: 8080
+
+command: []
 args: []
 
 config:
@@ -34,11 +39,23 @@ config:
   #         match:
   #           summary:
   #             prefix: "[Optional]"
+  #       - description: "Remove events without descriptions"
+  #         remove: true
+  #         match:
+  #           description:
+  #             empty: true
   #       - description: "Remove public holidays"
   #         remove: true
   #         match:
   #           summary:
   #             regex: ".*[Pp]ublic [Hh]oliday.*"
+  #       - description: "Rewrite matching event URLs"
+  #         match:
+  #           url:
+  #             contains: "teams.microsoft.com"
+  #         transform:
+  #           url:
+  #             replace: "https://example.com/meeting"
   #   - name: secrets
   #     feed_url_file: /run/secrets/url
   #     token_file: /run/secrets/token


### PR DESCRIPTION
Publishes the `ical-filter-proxy` Helm chart source into `charts/ical-filter-proxy` and bumps version to `0.3.0`.

The chart source is synchronized from `yungwood/ical-filter-proxy` and stale chart files are removed during publishing.