### PR TITLE
Update synergy-wholesale-exporter chart to 0.1.1

### DIFF
--- a/charts/synergy-wholesale-exporter/.helmignore
+++ b/charts/synergy-wholesale-exporter/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/synergy-wholesale-exporter/Chart.yaml
+++ b/charts/synergy-wholesale-exporter/Chart.yaml
@@ -1,0 +1,25 @@
+apiVersion: v2
+name: synergy-wholesale-exporter
+description: Prometheus exporter for Synergy Wholesale domains
+type: application
+home: https://github.com/yungwood/synergy-wholesale-exporter
+sources:
+  - https://github.com/yungwood/synergy-wholesale-exporter
+keywords:
+  - prometheus
+  - exporter
+  - domains
+  - synergy-wholesale
+version: 0.1.1
+appVersion: "0.1.1"
+maintainers:
+  - name: yungwood
+    url: https://github.com/yungwood
+annotations:
+  artifacthub.io/category: monitoring-logging
+  artifacthub.io/license: MIT
+  artifacthub.io/links: |
+    - name: Source
+      url: https://github.com/yungwood/synergy-wholesale-exporter
+    - name: Helm repository
+      url: https://yungwood.github.io/helm-charts/

--- a/charts/synergy-wholesale-exporter/README.md
+++ b/charts/synergy-wholesale-exporter/README.md
@@ -1,0 +1,147 @@
+# synergy-wholesale-exporter
+
+Helm chart for deploying [`synergy-wholesale-exporter`](https://github.com/yungwood/synergy-wholesale-exporter).
+
+## Install
+
+Add the Helm repository:
+
+```bash
+helm repo add yungwood https://yungwood.github.io/helm-charts/
+helm repo update
+```
+
+Create a Secret with your Synergy Wholesale credentials:
+
+```bash
+kubectl create secret generic synergy-wholesale-exporter \
+  --from-literal=reseller-id='12345' \
+  --from-literal=api-key='secret'
+```
+
+Install the chart using that Secret:
+
+```bash
+helm install synergy-wholesale-exporter yungwood/synergy-wholesale-exporter \
+  --set secret.name=synergy-wholesale-exporter
+```
+
+Alternatively, let the chart create the Secret:
+
+```bash
+helm install synergy-wholesale-exporter yungwood/synergy-wholesale-exporter \
+  --set secret.create=true \
+  --set-string secret.resellerID='12345' \
+  --set secret.apiKey='secret'
+```
+
+## Values
+
+| Value | Description | Default |
+|-------|-------------|---------|
+| `image.repository` | Image repository | `yungwood/synergy-wholesale-exporter` |
+| `image.tag` | Image tag. Defaults to chart `appVersion` when empty. | `""` |
+| `image.pullPolicy` | Image pull policy | `IfNotPresent` |
+| `replicaCount` | Number of replicas | `1` |
+| `env` | Additional container environment variables | `[]` |
+| `envFrom` | Additional container `envFrom` sources | `[]` |
+| `config.address` | Exporter listen address | `:8080` |
+| `config.cacheTTL` | Synergy Wholesale API cache TTL in seconds | `3600` |
+| `config.apiErrorBackoffMin` | Minimum backoff after failed API requests in seconds | `60` |
+| `config.apiErrorBackoffMax` | Maximum backoff after failed API requests in seconds | `3600` |
+| `config.debug` | Enable debug logging | `false` |
+| `config.json` | Enable JSON logging | `false` |
+| `config.golangMetrics` | Enable Go/process metrics | `false` |
+| `config.dnssecMetrics` | Enable DNSSEC key info metrics | `false` |
+| `secret.create` | Create a Kubernetes Secret from chart values | `false` |
+| `secret.name` | Existing Secret name. Defaults to chart fullname when empty. | `""` |
+| `secret.resellerID` | Reseller ID used when `secret.create=true` | `""` |
+| `secret.apiKey` | API key used when `secret.create=true` | `""` |
+| `secret.resellerIDKey` | Secret key containing reseller ID | `reseller-id` |
+| `secret.apiKeyKey` | Secret key containing API key | `api-key` |
+| `prometheus.serviceMonitor.enabled` | Create a Prometheus Operator `ServiceMonitor` | `false` |
+| `prometheus.serviceMonitor.labels` | Extra labels for the `ServiceMonitor` | `{}` |
+| `prometheus.prometheusRule.enabled` | Create a Prometheus Operator `PrometheusRule` | `false` |
+| `prometheus.prometheusRule.labels` | Extra labels for the `PrometheusRule` | `{}` |
+| `prometheus.prometheusRule.defaultAlertLabels` | Extra labels added to every alert | `{}` |
+| `prometheus.prometheusRule.alerts.*.enabled` | Enable an individual alert | See `values.yaml` |
+| `prometheus.prometheusRule.alerts.*.labels` | Labels for an individual alert | See `values.yaml` |
+| `prometheus.prometheusRule.alerts.*.annotations` | Extra annotations for an individual alert | `{}` |
+| `prometheus.prometheusRule.alerts.*.for` | Alert hold duration | See `values.yaml` |
+| `prometheus.prometheusRule.alerts.apiRequestErrors.window` | API error alert lookback window | `15m` |
+| `prometheus.prometheusRule.alerts.apiRequestErrors.threshold` | API error alert failure threshold within the lookback window | `3` |
+| `prometheus.prometheusRule.alerts.cacheStale.thresholdSeconds` | Cache stale alert threshold in seconds | `86400` |
+| `service.type` | Kubernetes Service type | `ClusterIP` |
+| `service.port` | Kubernetes Service port | `8080` |
+| `resources` | Container resource requests/limits | `{}` |
+| `nodeSelector` | Node selector | `{}` |
+| `tolerations` | Tolerations | `[]` |
+| `affinity` | Affinity rules | `{}` |
+| `extraDeploy` | Additional manifests to deploy. Items can be objects or templated YAML strings. | `[]` |
+
+Command-line args can be passed through `args`, but prefer the `config` values for standard exporter settings.
+
+## Extra Environment
+
+Use `env` and `envFrom` to add additional container environment variables:
+
+```yaml
+env:
+  - name: EXTRA_SETTING
+    value: enabled
+
+envFrom:
+  - secretRef:
+      name: extra-secret
+```
+
+## Extra Manifests
+
+Use `extraDeploy` to add related manifests that are not built into the chart:
+
+```yaml
+extraDeploy:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: extra-config
+    data:
+      example: value
+  - |
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: {{ include "synergy-wholesale-exporter.fullname" . }}-extra
+    stringData:
+      example: value
+```
+
+## Prometheus
+
+Enable `ServiceMonitor` if you use the Prometheus Operator:
+
+```yaml
+prometheus:
+  serviceMonitor:
+    enabled: true
+```
+
+The chart can also create a `PrometheusRule` with starter alerts:
+
+```yaml
+prometheus:
+  prometheusRule:
+    enabled: true
+    defaultAlertLabels:
+      team: platform
+    alerts:
+      domainAutoRenewDisabled:
+        enabled: true
+      domainExpiringSoon:
+        labels:
+          severity: warning
+        annotations:
+          runbook_url: https://example.com/runbooks/domain-expiry
+```
+
+Included alerts cover exporter scrape health, Synergy Wholesale API errors, stale cache refreshes, domain expiry, and optionally disabled auto-renew.

--- a/charts/synergy-wholesale-exporter/ci/install-values.yaml
+++ b/charts/synergy-wholesale-exporter/ci/install-values.yaml
@@ -1,0 +1,10 @@
+secret:
+  create: true
+  resellerID: "12345"
+  apiKey: "test-api-key"
+
+prometheus:
+  serviceMonitor:
+    enabled: false
+  prometheusRule:
+    enabled: false

--- a/charts/synergy-wholesale-exporter/templates/_helpers.tpl
+++ b/charts/synergy-wholesale-exporter/templates/_helpers.tpl
@@ -1,0 +1,81 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "synergy-wholesale-exporter.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "synergy-wholesale-exporter.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "synergy-wholesale-exporter.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "synergy-wholesale-exporter.labels" -}}
+helm.sh/chart: {{ include "synergy-wholesale-exporter.chart" . }}
+{{ include "synergy-wholesale-exporter.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "synergy-wholesale-exporter.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "synergy-wholesale-exporter.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "synergy-wholesale-exporter.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "synergy-wholesale-exporter.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the name of the secret containing Synergy Wholesale credentials.
+*/}}
+{{- define "synergy-wholesale-exporter.secretName" -}}
+{{- default (include "synergy-wholesale-exporter.fullname" .) .Values.secret.name }}
+{{- end }}
+
+{{/*
+Renders a value that may contain a template.
+*/}}
+{{- define "synergy-wholesale-exporter.tplRender" -}}
+{{- $value := typeIs "string" .value | ternary .value (.value | toYaml) }}
+{{- if contains "{{" $value }}
+{{- tpl $value .context }}
+{{- else }}
+{{- $value }}
+{{- end }}
+{{- end -}}

--- a/charts/synergy-wholesale-exporter/templates/deployment.yaml
+++ b/charts/synergy-wholesale-exporter/templates/deployment.yaml
@@ -1,0 +1,107 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "synergy-wholesale-exporter.fullname" . }}
+  labels:
+    {{- include "synergy-wholesale-exporter.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit | default "3" }}
+  selector:
+    matchLabels:
+      {{- include "synergy-wholesale-exporter.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "synergy-wholesale-exporter.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "synergy-wholesale-exporter.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args: {{ .Values.args }}
+          {{- with .Values.command }}
+          command: 
+            {{- toYaml . | nindent 12  }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          env:
+            - name: SYNERGY_WHOLESALE_RESELLER_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "synergy-wholesale-exporter.secretName" . }}
+                  key: {{ .Values.secret.resellerIDKey }}
+            - name: SYNERGY_WHOLESALE_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "synergy-wholesale-exporter.secretName" . }}
+                  key: {{ .Values.secret.apiKeyKey }}
+            - name: SYNERGY_WHOLESALE_EXPORTER_ADDRESS
+              value: {{ .Values.config.address | quote }}
+            - name: SYNERGY_WHOLESALE_EXPORTER_CACHE_TTL
+              value: {{ .Values.config.cacheTTL | quote }}
+            - name: SYNERGY_WHOLESALE_EXPORTER_API_ERROR_BACKOFF_MIN
+              value: {{ .Values.config.apiErrorBackoffMin | quote }}
+            - name: SYNERGY_WHOLESALE_EXPORTER_API_ERROR_BACKOFF_MAX
+              value: {{ .Values.config.apiErrorBackoffMax | quote }}
+            - name: SYNERGY_WHOLESALE_EXPORTER_DEBUG
+              value: {{ .Values.config.debug | quote }}
+            - name: SYNERGY_WHOLESALE_EXPORTER_JSON
+              value: {{ .Values.config.json | quote }}
+            - name: SYNERGY_WHOLESALE_EXPORTER_GOLANG_METRICS
+              value: {{ .Values.config.golangMetrics | quote }}
+            - name: SYNERGY_WHOLESALE_EXPORTER_DNSSEC_METRICS
+              value: {{ .Values.config.dnssecMetrics | quote }}
+            {{- with .Values.env }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/synergy-wholesale-exporter/templates/extra-deploy.yaml
+++ b/charts/synergy-wholesale-exporter/templates/extra-deploy.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraDeploy }}
+---
+{{ include "synergy-wholesale-exporter.tplRender" (dict "value" . "context" $) }}
+{{- end }}

--- a/charts/synergy-wholesale-exporter/templates/prometheusrule.yaml
+++ b/charts/synergy-wholesale-exporter/templates/prometheusrule.yaml
@@ -1,0 +1,137 @@
+{{- if .Values.prometheus.prometheusRule.enabled -}}
+{{- $rule := .Values.prometheus.prometheusRule -}}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ include "synergy-wholesale-exporter.fullname" . }}
+  labels:
+    {{- include "synergy-wholesale-exporter.labels" . | nindent 4 }}
+    {{- with $rule.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  groups:
+    - name: synergy-wholesale-exporter
+      rules:
+        {{- with $rule.alerts.exporterDown }}
+        {{- if .enabled }}
+        - alert: SynergyWholesaleExporterDown
+          expr: up{job="{{ include "synergy-wholesale-exporter.fullname" $ }}"} == 0
+          for: {{ .for }}
+          labels:
+            {{- with $rule.defaultAlertLabels }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with .labels }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          annotations:
+            summary: Synergy Wholesale exporter is down
+            description: Prometheus has not been able to scrape the Synergy Wholesale exporter.
+            {{- with .annotations }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+        {{- end }}
+        {{- end }}
+        {{- with $rule.alerts.apiRequestErrors }}
+        {{- if .enabled }}
+        - alert: SynergyWholesaleAPIRequestErrors
+          expr: increase(synergy_wholesale_api_requests_total{result="error"}[{{ .window }}]) > {{ .threshold }}
+          for: {{ .for }}
+          labels:
+            {{- with $rule.defaultAlertLabels }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with .labels }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          annotations:
+            summary: Synergy Wholesale API requests are failing
+            description: The exporter has recorded more than {{ .threshold }} failed Synergy Wholesale API requests in the last {{ .window }}.
+            {{- with .annotations }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+        {{- end }}
+        {{- end }}
+        {{- with $rule.alerts.cacheStale }}
+        {{- if .enabled }}
+        - alert: SynergyWholesaleCacheStale
+          expr: time() - synergy_wholesale_cache_last_successful_refresh_timestamp_seconds > {{ .thresholdSeconds }}
+          for: {{ .for }}
+          labels:
+            {{- with $rule.defaultAlertLabels }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with .labels }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          annotations:
+            summary: Synergy Wholesale exporter cache is stale
+            description: The exporter has not successfully refreshed its domain cache for more than {{ .thresholdSeconds }} seconds.
+            {{- with .annotations }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+        {{- end }}
+        {{- end }}
+        {{- with $rule.alerts.domainExpiringSoon }}
+        {{- if .enabled }}
+        - alert: SynergyWholesaleDomainExpiringSoon
+          expr: synergy_wholesale_domain_expiry_timestamp_seconds - time() < {{ mul .thresholdDays 86400 }} and synergy_wholesale_domain_expiry_timestamp_seconds - time() > {{ mul .criticalThresholdDays 86400 }}
+          for: {{ .for }}
+          labels:
+            {{- with $rule.defaultAlertLabels }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with .labels }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          annotations:
+            summary: Synergy Wholesale domain is expiring soon
+            description: Domain {{ "{{ $labels.domain }}" }} expires within {{ .thresholdDays }} days.
+            {{- with .annotations }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+        {{- end }}
+        {{- end }}
+        {{- with $rule.alerts.domainExpiryCritical }}
+        {{- if .enabled }}
+        - alert: SynergyWholesaleDomainExpiryCritical
+          expr: synergy_wholesale_domain_expiry_timestamp_seconds - time() <= {{ mul .thresholdDays 86400 }}
+          for: {{ .for }}
+          labels:
+            {{- with $rule.defaultAlertLabels }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with .labels }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          annotations:
+            summary: Synergy Wholesale domain expiry is critical
+            description: Domain {{ "{{ $labels.domain }}" }} expires within {{ .thresholdDays }} days or has already expired.
+            {{- with .annotations }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+        {{- end }}
+        {{- end }}
+        {{- with $rule.alerts.domainAutoRenewDisabled }}
+        {{- if .enabled }}
+        - alert: SynergyWholesaleDomainAutoRenewDisabled
+          expr: synergy_wholesale_domain_auto_renew_enabled == 0
+          for: {{ .for }}
+          labels:
+            {{- with $rule.defaultAlertLabels }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with .labels }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          annotations:
+            summary: Synergy Wholesale domain auto-renew is disabled
+            description: Domain {{ "{{ $labels.domain }}" }} has auto-renew disabled.
+            {{- with .annotations }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+        {{- end }}
+        {{- end }}
+{{- end }}

--- a/charts/synergy-wholesale-exporter/templates/secret.yaml
+++ b/charts/synergy-wholesale-exporter/templates/secret.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.secret.create -}}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "synergy-wholesale-exporter.secretName" . }}
+  labels:
+    {{- include "synergy-wholesale-exporter.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{ .Values.secret.resellerIDKey }}: {{ required "secret.resellerID is required when secret.create is true" .Values.secret.resellerID | quote }}
+  {{ .Values.secret.apiKeyKey }}: {{ required "secret.apiKey is required when secret.create is true" .Values.secret.apiKey | quote }}
+{{- end }}

--- a/charts/synergy-wholesale-exporter/templates/service.yaml
+++ b/charts/synergy-wholesale-exporter/templates/service.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "synergy-wholesale-exporter.fullname" . }}
+  labels:
+    {{- include "synergy-wholesale-exporter.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "synergy-wholesale-exporter.selectorLabels" . | nindent 4 }}

--- a/charts/synergy-wholesale-exporter/templates/serviceaccount.yaml
+++ b/charts/synergy-wholesale-exporter/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.serviceAccount.create -}}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "synergy-wholesale-exporter.serviceAccountName" . }}
+  labels:
+    {{- include "synergy-wholesale-exporter.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/charts/synergy-wholesale-exporter/templates/servicemonitor.yaml
+++ b/charts/synergy-wholesale-exporter/templates/servicemonitor.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.prometheus.serviceMonitor.enabled -}}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "synergy-wholesale-exporter.fullname" . }}
+  labels:
+    {{- include "synergy-wholesale-exporter.labels" . | nindent 4 }}
+    {{- with .Values.prometheus.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "synergy-wholesale-exporter.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: http
+      path: /metrics
+{{- end }}

--- a/charts/synergy-wholesale-exporter/values.schema.json
+++ b/charts/synergy-wholesale-exporter/values.schema.json
@@ -1,0 +1,418 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "affinity": {
+            "properties": {},
+            "type": "object"
+        },
+        "args": {
+            "type": "array"
+        },
+        "command": {
+            "type": "array"
+        },
+        "config": {
+            "additionalProperties": false,
+            "properties": {
+                "address": {
+                    "type": "string"
+                },
+                "apiErrorBackoffMax": {
+                    "type": "integer"
+                },
+                "apiErrorBackoffMin": {
+                    "type": "integer"
+                },
+                "cacheTTL": {
+                    "type": "integer"
+                },
+                "debug": {
+                    "type": "boolean"
+                },
+                "dnssecMetrics": {
+                    "type": "boolean"
+                },
+                "golangMetrics": {
+                    "type": "boolean"
+                },
+                "json": {
+                    "type": "boolean"
+                }
+            },
+            "required": ["address", "cacheTTL", "apiErrorBackoffMin", "apiErrorBackoffMax", "debug", "json", "golangMetrics", "dnssecMetrics"],
+            "type": "object"
+        },
+        "fullnameOverride": {
+            "type": "string"
+        },
+        "extraDeploy": {
+            "items": {
+                "oneOf": [
+                    {
+                        "type": "string"
+                    },
+                    {
+                        "type": "object"
+                    }
+                ]
+            },
+            "type": "array"
+        },
+        "env": {
+            "items": {
+                "type": "object"
+            },
+            "type": "array"
+        },
+        "envFrom": {
+            "items": {
+                "type": "object"
+            },
+            "type": "array"
+        },
+        "image": {
+            "additionalProperties": false,
+            "properties": {
+                "pullPolicy": {
+                    "type": "string",
+                    "enum": ["Always", "IfNotPresent", "Never"]
+                },
+                "repository": {
+                    "type": "string"
+                },
+                "tag": {
+                    "type": "string"
+                }
+            },
+            "required": ["repository", "pullPolicy"],
+            "type": "object"
+        },
+        "imagePullSecrets": {
+            "type": "array"
+        },
+        "livenessProbe": {
+            "properties": {},
+            "type": "object"
+        },
+        "nameOverride": {
+            "type": "string"
+        },
+        "nodeSelector": {
+            "properties": {},
+            "type": "object"
+        },
+        "podAnnotations": {
+            "properties": {},
+            "type": "object"
+        },
+        "podLabels": {
+            "properties": {},
+            "type": "object"
+        },
+        "podSecurityContext": {
+            "properties": {},
+            "type": "object"
+        },
+        "prometheus": {
+            "additionalProperties": false,
+            "properties": {
+                "serviceMonitor": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "labels": {
+                            "additionalProperties": {
+                                "type": "string"
+                            },
+                            "properties": {},
+                            "type": "object"
+                        }
+                    },
+                    "required": ["enabled", "labels"],
+                    "type": "object"
+                },
+                "prometheusRule": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "alerts": {
+                            "additionalProperties": false,
+                            "properties": {
+                                "apiRequestErrors": {
+                                    "$ref": "#/$defs/apiRequestErrorsAlert"
+                                },
+                                "cacheStale": {
+                                    "$ref": "#/$defs/cacheStaleAlert"
+                                },
+                                "domainAutoRenewDisabled": {
+                                    "$ref": "#/$defs/basicAlert"
+                                },
+                                "domainExpiringSoon": {
+                                    "$ref": "#/$defs/domainExpiringSoonAlert"
+                                },
+                                "domainExpiryCritical": {
+                                    "$ref": "#/$defs/domainExpiryCriticalAlert"
+                                },
+                                "exporterDown": {
+                                    "$ref": "#/$defs/basicAlert"
+                                }
+                            },
+                            "required": ["exporterDown", "apiRequestErrors", "cacheStale", "domainExpiringSoon", "domainExpiryCritical", "domainAutoRenewDisabled"],
+                            "type": "object"
+                        },
+                        "defaultAlertLabels": {
+                            "additionalProperties": {
+                                "type": "string"
+                            },
+                            "properties": {},
+                            "type": "object"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "labels": {
+                            "additionalProperties": {
+                                "type": "string"
+                            },
+                            "properties": {},
+                            "type": "object"
+                        }
+                    },
+                    "required": ["enabled", "labels", "defaultAlertLabels", "alerts"],
+                    "type": "object"
+                }
+            },
+            "required": ["serviceMonitor", "prometheusRule"],
+            "type": "object"
+        },
+        "readinessProbe": {
+            "properties": {},
+            "type": "object"
+        },
+        "replicaCount": {
+            "type": "integer"
+        },
+        "revisionHistoryLimit": {
+            "type": "integer"
+        },
+        "resources": {
+            "properties": {
+                "limits": {
+                    "properties": {},
+                    "type": "object"
+                },
+                "requests": {
+                    "properties": {},
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "securityContext": {
+            "properties": {},
+            "type": "object"
+        },
+        "secret": {
+            "additionalProperties": false,
+            "properties": {
+                "apiKey": {
+                    "type": "string"
+                },
+                "apiKeyKey": {
+                    "type": "string"
+                },
+                "create": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "resellerID": {
+                    "type": "string"
+                },
+                "resellerIDKey": {
+                    "type": "string"
+                }
+            },
+            "required": ["create", "name", "resellerID", "apiKey", "resellerIDKey", "apiKeyKey"],
+            "type": "object"
+        },
+        "service": {
+            "properties": {
+                "port": {
+                    "type": "integer"
+                },
+                "type": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "serviceAccount": {
+            "properties": {
+                "annotations": {
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "properties": {},
+                    "type": "object"
+                },
+                "automount": {
+                    "type": "boolean"
+                },
+                "create": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "tolerations": {
+            "type": "array"
+        },
+        "volumeMounts": {
+            "items": {
+                "properties": {
+                    "mountPath": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "readOnly": {
+                        "type": "boolean"
+                    }
+                },
+                "type": "object"
+            },
+            "type": "array"
+        },
+        "volumes": {
+            "items": {
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "secret": {
+                        "properties": {
+                            "optional": {
+                                "type": "boolean"
+                            },
+                            "secretName": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object"
+                    }
+                },
+                "type": "object"
+            },
+            "type": "array"
+        }
+    },
+    "$defs": {
+        "alertAnnotations": {
+            "additionalProperties": {
+                "type": "string"
+            },
+            "properties": {},
+            "type": "object"
+        },
+        "alertLabels": {
+            "additionalProperties": {
+                "type": "string"
+            },
+            "properties": {},
+            "type": "object"
+        },
+        "basicAlert": {
+            "properties": {
+                "annotations": {
+                    "$ref": "#/$defs/alertAnnotations"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "for": {
+                    "type": "string"
+                },
+                "labels": {
+                    "$ref": "#/$defs/alertLabels"
+                }
+            },
+            "required": ["enabled", "for", "labels", "annotations"],
+            "type": "object"
+        },
+        "apiRequestErrorsAlert": {
+            "allOf": [
+                {
+                    "$ref": "#/$defs/basicAlert"
+                },
+                {
+                    "properties": {
+                        "threshold": {
+                            "type": "integer"
+                        },
+                        "window": {
+                            "type": "string"
+                        }
+                    },
+                    "required": ["window", "threshold"]
+                }
+            ]
+        },
+        "cacheStaleAlert": {
+            "allOf": [
+                {
+                    "$ref": "#/$defs/basicAlert"
+                },
+                {
+                    "properties": {
+                        "thresholdSeconds": {
+                            "type": "integer"
+                        }
+                    },
+                    "required": ["thresholdSeconds"]
+                }
+            ]
+        },
+        "domainExpiringSoonAlert": {
+            "allOf": [
+                {
+                    "$ref": "#/$defs/basicAlert"
+                },
+                {
+                    "properties": {
+                        "criticalThresholdDays": {
+                            "type": "integer"
+                        },
+                        "thresholdDays": {
+                            "type": "integer"
+                        }
+                    },
+                    "required": ["thresholdDays", "criticalThresholdDays"]
+                }
+            ]
+        },
+        "domainExpiryCriticalAlert": {
+            "allOf": [
+                {
+                    "$ref": "#/$defs/basicAlert"
+                },
+                {
+                    "properties": {
+                        "thresholdDays": {
+                            "type": "integer"
+                        }
+                    },
+                    "required": ["thresholdDays"]
+                }
+            ]
+        }
+    },
+    "required": ["image", "config", "secret", "prometheus", "livenessProbe", "readinessProbe", "replicaCount", "resources", "extraDeploy", "env", "envFrom"],
+    "type": "object"
+}

--- a/charts/synergy-wholesale-exporter/values.yaml
+++ b/charts/synergy-wholesale-exporter/values.yaml
@@ -1,0 +1,153 @@
+image:
+  repository: yungwood/synergy-wholesale-exporter
+  pullPolicy: IfNotPresent
+  tag: ""  # defaults to chart appVersion
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+replicaCount: 1
+
+args: []
+
+# command: []
+
+env: []
+
+envFrom: []
+
+config:
+  address: ":8080"
+  cacheTTL: 3600
+  apiErrorBackoffMin: 60
+  apiErrorBackoffMax: 3600
+  debug: false
+  json: false
+  golangMetrics: false
+  dnssecMetrics: false
+
+secret:
+  # If create is false, create a Kubernetes Secret separately and set name if it
+  # differs from the chart fullname.
+  create: false
+  name: ""
+  # Used only when create is true.
+  resellerID: ""
+  apiKey: ""
+  resellerIDKey: reseller-id
+  apiKeyKey: api-key
+
+prometheus:
+  serviceMonitor:
+    enabled: false
+    labels: {}
+  prometheusRule:
+    enabled: false
+    labels: {}
+    defaultAlertLabels: {}
+    alerts:
+      exporterDown:
+        enabled: true
+        for: 10m
+        labels:
+          severity: critical
+        annotations: {}
+      apiRequestErrors:
+        enabled: true
+        for: 5m
+        window: 15m
+        threshold: 3
+        labels:
+          severity: warning
+        annotations: {}
+      cacheStale:
+        enabled: true
+        for: 10m
+        thresholdSeconds: 86400
+        labels:
+          severity: warning
+        annotations: {}
+      domainExpiringSoon:
+        enabled: true
+        for: 1h
+        thresholdDays: 30
+        criticalThresholdDays: 7
+        labels:
+          severity: warning
+        annotations: {}
+      domainExpiryCritical:
+        enabled: true
+        for: 15m
+        thresholdDays: 7
+        labels:
+          severity: critical
+        annotations: {}
+      domainAutoRenewDisabled:
+        enabled: false
+        for: 1h
+        labels:
+          severity: warning
+        annotations: {}
+
+serviceAccount:
+  create: true
+  automount: false
+  annotations: {}
+  name: ""
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext:
+  capabilities:
+    drop:
+      - ALL
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 3000
+
+service:
+  type: ClusterIP
+  port: 8080
+
+resources: {}
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+livenessProbe:
+  httpGet:
+    path: /liveness
+    port: http
+readinessProbe:
+  httpGet:
+    path: /readiness
+    port: http
+
+volumes: []
+# - name: foo
+#   secret:
+#     secretName: mysecret
+#     optional: false
+
+volumeMounts: []
+# - name: foo
+#   mountPath: "/etc/foo"
+#   readOnly: true
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+extraDeploy: []


### PR DESCRIPTION
Publishes the `synergy-wholesale-exporter` Helm chart source into `charts/synergy-wholesale-exporter`.

- Source ref: [0.1.1](https://github.com/yungwood/synergy-wholesale-exporter/tree/0.1.1)
- Source commit: [588fccef1eb7e531e56b6c144928d1c69e9926ad](https://github.com/yungwood/synergy-wholesale-exporter/commit/588fccef1eb7e531e56b6c144928d1c69e9926ad)
- Release: [0.1.1](https://github.com/yungwood/synergy-wholesale-exporter/releases/tag/0.1.1)

The chart source is synchronized from `yungwood/synergy-wholesale-exporter` and stale chart files are removed during publishing.

Closes #12.